### PR TITLE
[OU-ADD] stock: tests

### DIFF
--- a/openupgrade_scripts/scripts/stock/tests/data_pull.py
+++ b/openupgrade_scripts/scripts/stock/tests/data_pull.py
@@ -1,0 +1,79 @@
+env = locals().get("env")
+# create two step pull route, procure a product with it
+intermediate_location = env["stock.location"].create(
+    {
+        "name": "Intermediate location",
+        "usage": "internal",
+    }
+)
+env["ir.model.data"]._update_xmlids(
+    [
+        {
+            "xml_id": "openupgrade_test_stock.intermediate_pull_location",
+            "record": intermediate_location,
+        }
+    ]
+)
+two_step_route = env["stock.route"].create(
+    {
+        "name": "2 steps",
+        "rule_ids": [
+            (
+                0,
+                0,
+                {
+                    "name": "Stock → Intermediate",
+                    "location_src_id": env.ref("stock.stock_location_stock").id,
+                    "location_dest_id": intermediate_location.id,
+                    "picking_type_id": env.ref("stock.picking_type_internal").id,
+                    "action": "pull",
+                    #            'location_dest_from_rule': True, # v18
+                },
+            ),
+            (
+                0,
+                0,
+                {
+                    "name": "Intermediate → Customer",
+                    "location_src_id": intermediate_location.id,
+                    "location_dest_id": env.ref("stock.stock_location_customers").id,
+                    "picking_type_id": env.ref("stock.picking_type_internal").id,
+                    "procure_method": "make_to_order",
+                    "action": "pull",
+                    #            'location_dest_from_rule': True, # v18
+                },
+            ),
+        ],
+    }
+)
+product = env["product.product"].create(
+    {
+        "name": "2 step product (pull)",
+        "type": "product",
+        #    'type': 'consu', # v18
+        "route_ids": [(6, 0, two_step_route.ids)],
+    }
+)
+env["ir.model.data"]._update_xmlids(
+    [{"xml_id": "openupgrade_test_stock.pull_product", "record": product}]
+)
+procurement_group = env["procurement.group"].create(
+    {
+        "name": "2 step procurement",
+    }
+)
+env["procurement.group"].run(
+    [
+        env["procurement.group"].Procurement(
+            product_id=product,
+            product_qty=42,
+            product_uom=product.uom_id,
+            location_id=env.ref("stock.stock_location_customers"),
+            name="2 step procurement",
+            origin="/",
+            company_id=env.company,
+            values={"group_id": procurement_group},
+        ),
+    ]
+)
+env.cr.commit()

--- a/openupgrade_scripts/scripts/stock/tests/data_push.py
+++ b/openupgrade_scripts/scripts/stock/tests/data_push.py
@@ -1,0 +1,72 @@
+env = locals().get("env")
+# create two step push route, move a product there
+intermediate_location = env["stock.location"].create(
+    {
+        "name": "Intermediate location",
+        "usage": "internal",
+    }
+)
+env["ir.model.data"]._update_xmlids(
+    [
+        {
+            "xml_id": "openupgrade_test_stock.intermediate_push_location",
+            "record": intermediate_location,
+        }
+    ]
+)
+two_step_route = env["stock.route"].create(
+    {
+        "name": "2 steps",
+        "rule_ids": [
+            (
+                0,
+                0,
+                {
+                    "name": "Stock → Intermediate",
+                    "location_src_id": env.ref("stock.stock_location_stock").id,
+                    "location_dest_id": intermediate_location.id,
+                    "picking_type_id": env.ref("stock.picking_type_internal").id,
+                    "action": "push",
+                },
+            ),
+            (
+                0,
+                0,
+                {
+                    "name": "Intermediate → Customer",
+                    "location_src_id": intermediate_location.id,
+                    "location_dest_id": env.ref("stock.stock_location_customers").id,
+                    "picking_type_id": env.ref("stock.picking_type_out").id,
+                    "action": "push",
+                },
+            ),
+        ],
+    }
+)
+product = env["product.product"].create(
+    {
+        "name": "2 step product (push)",
+        "type": "product",
+        #    'type': 'consu', # v18
+        "route_ids": [(6, 0, two_step_route.ids)],
+    }
+)
+env["ir.model.data"]._update_xmlids(
+    [{"xml_id": "openupgrade_test_stock.push_product", "record": product}]
+)
+in_move = env["stock.move"].create(
+    {
+        "name": "in",
+        "location_id": env.ref("stock.stock_location_suppliers").id,
+        "location_dest_id": env.ref("stock.stock_location_stock").id,
+        #    'location_final_id': env.ref('stock.stock_location_customers').id,
+        "route_ids": [(6, 0, two_step_route.ids)],
+        "product_id": product.id,
+        "quantity": 42,
+        "product_uom_qty": 42,
+        "picked": True,
+    }
+)
+in_move._action_done()
+in_move.move_dest_ids._action_done()
+env.cr.commit()

--- a/openupgrade_scripts/scripts/stock/tests/test_migration.py
+++ b/openupgrade_scripts/scripts/stock/tests/test_migration.py
@@ -1,0 +1,138 @@
+from odoo.tests import TransactionCase
+
+from odoo.addons.openupgrade_framework import openupgrade_test
+
+
+@openupgrade_test
+class TestStockMigration(TransactionCase):
+    def test_picking_type_required_fields(self):
+        """Test that newly required fields are set"""
+        # TODO: this fails with demo data
+        for picking_type in self.env["stock.picking.type"].search([]):
+            self.assertTrue(picking_type.default_location_src_id)
+            self.assertTrue(picking_type.default_location_dest_id)
+
+    def test_pull_moves(self):
+        """
+        Test that pull moves have been migrated correctly and new moves yield the
+        same result
+        """
+        product = self.env.ref("openupgrade_test_stock.pull_product")
+        stock_location = self.env.ref("stock.stock_location_stock")
+        intermediate_location = self.env.ref(
+            "openupgrade_test_stock.intermediate_pull_location"
+        )
+        customer_location = self.env.ref("stock.stock_location_customers")
+
+        moves = self.env["stock.move"].search([("product_id", "=", product.id)])
+        from_stock = moves.filtered(lambda x: x.location_id == stock_location)
+        from_intermediate = moves.filtered(
+            lambda x: x.location_id == intermediate_location
+        )
+
+        self.assertEqual(from_stock.location_dest_id, intermediate_location)
+        self.assertEqual(from_stock.location_final_id, intermediate_location)
+
+        self.assertEqual(from_intermediate.location_dest_id, customer_location)
+        self.assertEqual(from_intermediate.location_final_id, customer_location)
+
+        # TODO: this should be done by migration
+        self.env["stock.rule"].search(
+            [
+                "|",
+                ("location_src_id", "=", intermediate_location.id),
+                ("location_dest_id", "=", intermediate_location.id),
+            ]
+        ).location_dest_from_rule = True
+
+        procurement_group = self.env["procurement.group"].create(
+            {
+                "name": "2 step procurement v18",
+            }
+        )
+        self.env["procurement.group"].run(
+            [
+                self.env["procurement.group"].Procurement(
+                    product_id=product,
+                    product_qty=42,
+                    product_uom=product.uom_id,
+                    location_id=self.env.ref("stock.stock_location_customers"),
+                    name="2 step procurement",
+                    origin="/",
+                    company_id=self.env.company,
+                    values={"group_id": procurement_group},
+                ),
+            ]
+        )
+
+        new_moves = (
+            self.env["stock.move"].search([("product_id", "=", product.id)]) - moves
+        )
+        from_stock = new_moves.filtered(lambda x: x.location_id == stock_location)
+        from_intermediate = new_moves.filtered(
+            lambda x: x.location_id == intermediate_location
+        )
+
+        self.assertEqual(from_stock.location_dest_id, intermediate_location)
+        self.assertEqual(from_stock.location_final_id, intermediate_location)
+
+        self.assertEqual(from_intermediate.location_dest_id, customer_location)
+        self.assertEqual(from_intermediate.location_final_id, customer_location)
+
+    def test_push_moves(self):
+        """
+        Test that push moves have been migrated correctly and new moves yield the
+        same result
+        """
+        product = self.env.ref("openupgrade_test_stock.push_product")
+        stock_location = self.env.ref("stock.stock_location_stock")
+        intermediate_location = self.env.ref(
+            "openupgrade_test_stock.intermediate_push_location"
+        )
+        customer_location = self.env.ref("stock.stock_location_customers")
+
+        moves = self.env["stock.move"].search([("product_id", "=", product.id)])
+
+        from_stock = moves.filtered(lambda x: x.location_id == stock_location)
+        from_intermediate = moves.filtered(
+            lambda x: x.location_id == intermediate_location
+        )
+
+        self.assertEqual(from_stock.location_dest_id, intermediate_location)
+        # TODO: this fails because we don't set this from move_dest_ids/route_ids
+        self.assertEqual(from_stock.location_final_id, customer_location)
+
+        self.assertEqual(from_intermediate.location_dest_id, customer_location)
+        self.assertEqual(from_intermediate.location_final_id, customer_location)
+
+        in_move = self.env["stock.move"].create(
+            {
+                "name": "in",
+                "location_id": self.env.ref("stock.stock_location_suppliers").id,
+                "location_dest_id": stock_location.id,
+                "location_final_id": customer_location.id,
+                "route_ids": [(6, 0, moves.route_ids.ids)],
+                "product_id": product.id,
+                "quantity": 42,
+                "product_uom_qty": 42,
+                "picked": True,
+            }
+        )
+        in_move._action_done()
+        in_move.move_dest_ids.picked = True
+        in_move.move_dest_ids._action_done()
+
+        new_moves = (
+            self.env["stock.move"].search([("product_id", "=", product.id)]) - moves
+        )
+
+        from_stock = new_moves.filtered(lambda x: x.location_id == stock_location)
+        from_intermediate = new_moves.filtered(
+            lambda x: x.location_id == intermediate_location
+        )
+
+        self.assertEqual(from_stock.location_dest_id, intermediate_location)
+        self.assertEqual(from_stock.location_final_id, customer_location)
+
+        self.assertEqual(from_intermediate.location_dest_id, customer_location)
+        self.assertEqual(from_intermediate.location_final_id, customer_location)


### PR DESCRIPTION
I think it's helpful to first fix the desired behavior post migration, and then look into how to achieve this. I've added a couple of tests here that fail, let's take it from there.

My suggestion would be:

- copy location_dest_id to location_final_id
- set location_dest_from_rule for all pull rules
- for done moves created by push rules, set location_final_id to last location_dst_id